### PR TITLE
プロフィール更新の際のパスワード入力を廃止

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # 本番環境
 https://expressive-writing.work/
-テストユーザでログインできます。
+<br>テストユーザでログインできます。
 
 # 使用技術
 - Ruby 2.5.1

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,7 @@
+class RegistrationsController < Devise::RegistrationsController
+
+  protected
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,6 +1,6 @@
 class RegistrationsController < Devise::RegistrationsController
-
   protected
+
   def update_resource(resource, params)
     resource.update_without_password(params)
   end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -37,12 +37,6 @@
           = f.label :password_confirmation
           %br/
           = f.password_field :password_confirmation, autocomplete: "new-password"
-        .field
-          = f.label :current_password
-          %i 
-            = t('view.current_password_information')
-          %br/
-          = f.password_field :current_password, autocomplete: "current-password"
         %button.btn.waves-effect.waves-light
           = f.submit "#{t('view.update')}"
           %i.material-icons.right send

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: { registrations: 'registrations', 
+  omniauth_callbacks: 'users/omniauth_callbacks' }
 
   resources    :posts do
     resources  :comments, only: %i[edit update create destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { registrations: 'registrations', 
-  omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: { registrations: 'registrations',
+                                    omniauth_callbacks: 'users/omniauth_callbacks' }
 
   resources    :posts do
     resources  :comments, only: %i[edit update create destroy]


### PR DESCRIPTION
# WHAT
*プロフィール更新の際のパスワード入力を廃止する

# WHY
SNSログイン時にパスワードが不明なため廃止する